### PR TITLE
Fix contact form layout

### DIFF
--- a/src/components/ContactForm.js
+++ b/src/components/ContactForm.js
@@ -5,18 +5,25 @@ const Form = styled.form`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  max-width: 600px;
+  width: 100%;
+  margin: 0 auto;
 `;
 
 const Input = styled.input`
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
 `;
 
 const TextArea = styled.textarea`
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
 `;
 
 const Button = styled.button`

--- a/src/components/JobForm.js
+++ b/src/components/JobForm.js
@@ -5,12 +5,17 @@ const Form = styled.form`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  max-width: 600px;
+  width: 100%;
+  margin: 0 auto;
 `;
 
 const Input = styled.input`
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
 `;
 
 const Button = styled.button`


### PR DESCRIPTION
## Summary
- keep ContactForm and JobForm from stretching across the screen
- make form inputs scale to device width

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: gatsby not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e93104ef8832f85f0a15e56daea3f