### PR TITLE
Add Google Analytics tag to layout

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -42,6 +42,17 @@ const MainContent = styled.main`
 const Layout = ({ children }) => (
   <SiteContainer>
     <Helmet>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-X7N99R0TW1"></script>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-X7N99R0TW1');
+      `,
+        }}
+      />
       <link rel="preconnect" href="https://fonts.googleapis.com" />
       <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
       <link


### PR DESCRIPTION
## Summary
- integrate Google Analytics `gtag.js` snippet into the global layout for site-wide tracking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689246bac76c832fa2071c8e9a5cb94e