### PR TITLE
feat: add Google Tag Manager

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,31 @@
+const React = require("react");
+
+exports.onRenderBody = ({ setHeadComponents, setPreBodyComponents }) => {
+  setHeadComponents([
+    React.createElement("script", {
+      key: "gtm-script",
+      dangerouslySetInnerHTML: {
+        __html:
+          "(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':" +
+          "new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0]," +
+          "j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=" +
+          "'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);" +
+          "})(window,document,'script','dataLayer','GTM-KK6Z54TR');",
+      },
+    }),
+  ]);
+
+  setPreBodyComponents([
+    React.createElement(
+      "noscript",
+      { key: "gtm-noscript" },
+      React.createElement("iframe", {
+        src: "https://www.googletagmanager.com/ns.html?id=GTM-KK6Z54TR",
+        height: "0",
+        width: "0",
+        style: { display: "none", visibility: "hidden" },
+      })
+    ),
+  ]);
+};
+


### PR DESCRIPTION
## Summary
- inject Google Tag Manager script and noscript snippets into every page via `gatsby-ssr.js`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68924aa1e9c4832f96703c6720388dae